### PR TITLE
SIGKILL cannot be caught

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -44,7 +44,6 @@ function Service (amino, name, server, options) {
   // Unpublish our spec if process closes.
   self.processListeners = {
     SIGINT: this.onTerminate('SIGINT'),
-    SIGKILL: this.onTerminate('SIGKILL'),
     SIGTERM: this.onTerminate('SIGTERM'),
     uncaughtException: this.onTerminate('uncaughtException')
   };


### PR DESCRIPTION
Node 0.10 seems to reflect the fact that `SIGKILL` [cannot be caught](http://pubs.opengroup.org/onlinepubs/009696699/basedefs/signal.h.html) by throwing an exception when trying to listen to that signal.

This patch removes `SIGKILL` from `service.processListeners` which resolves the failing test in issue #1.
