### PR TITLE
Emit error when ip address lookup fails.

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -28,8 +28,8 @@ function Service (amino, name, server, options) {
 
   // Attempt to get my address.
   self.ipAddress(function (err, address) {
-    if (err) {
-      self.emit('error', new Error("could not autodetect host! Try setting service.options.host manually."));
+    if (err || !address) {
+      self.emit('error', err || new Error("could not autodetect host! Try setting service.options.host manually."));
       return;
     }
 


### PR DESCRIPTION
Failure can be either an error or a non-error failure (due to OS wonkiness).

And make the error emitted be more specific: pass the `Error` or our custom error.
