### PR TITLE
Guard against process.removeListener throwing

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -138,7 +138,12 @@ Service.prototype.onClose = function () {
 
     // If the server is manually closed, we don't want an event listener leak.
     Object.keys(this.processListeners).forEach(function (k) {
-      process.removeListener(k, self.processListeners[k]);
+      // Guard against already removed listeners. Unlike ordinary events
+      // trying to remove a signal listener from process when there are no
+      // listeners for that signal will cause an error to be thrown:
+      // https://github.com/joyent/node/blob/v0.10.28/src/node.js#L779
+      try { process.removeListener(k, self.processListeners[k]); }
+      catch (e) {}
     });
   }
   this.emit('close');


### PR DESCRIPTION
Was noticing that it took 2x ^C to kill the app. This was causing a problem in production, too, because `amino stop` or `amino redeploy` couldn't kill the running processes.

Turns out, unlike plain-jane events, if you try to remove a signal listener from `process` (e.g., `SIGINT`, `SIGTERM`, etc.), node internally asserts that there are listeners for that signal -- meaning, if there aren't, it throws.

See: https://github.com/joyent/node/blob/v0.10.28/src/node.js#L779

If this section of code throws, then the service was in the middle of closing, but never emitted "close". So the onClose handler never fires, and the process doesn't exit. That's why the first ^C doesn't work.

This is probably the reason why originally, the handlers were attached with `on` instead of `once`. https://github.com/amino/amino-service/pull/5#issuecomment-29011463
